### PR TITLE
Fix for missing clusters on printout

### DIFF
--- a/PointClustering/ClusterFeatureLayer.js
+++ b/PointClustering/ClusterFeatureLayer.js
@@ -175,7 +175,8 @@ define([
       this._singleRenderer = options.singleRenderer;
 
       this._objectIdField = options.objectIdField || 'OBJECTID';
-
+      this._opacity = options.hasOwnProperty('opacity') ? options.opacity : 1;
+      
       if (!this.url) {
         throw new Error('url is a required parameter');
       }
@@ -283,9 +284,10 @@ define([
 
                 renderer.addBreak(2, 10, small);
                 renderer.addBreak(10, 25, medium);
-                renderer.addBreak(25, Infinity, large);
+                renderer.addBreak(25, 10000, large);
                 this.setRenderer(renderer);
               }
+              this.setOpacity(this._opacity);
               this._reCluster();
             }));
           }
@@ -638,7 +640,7 @@ define([
       }
 
       // show number of points in the cluster
-      var label = new TextSymbol(c.attributes.clusterCount)
+      var label = new TextSymbol(c.attributes.clusterCount.toString())
         .setColor(new Color(this._clusterLabelColor))
         .setOffset(0, this._clusterLabelOffset)
         .setFont(this._font);
@@ -687,7 +689,7 @@ define([
       if ( label.length == 1 ) {
         // console.log('update label...found: ', label);
         this.remove(label[0]);
-        var newLabel = new TextSymbol(c.attributes.clusterCount)
+        var newLabel = new TextSymbol(c.attributes.clusterCount.toString())
           .setColor(new Color(this._clusterLabelColor))
           .setOffset(0, this._clusterLabelOffset)
           .setFont(this._font);


### PR DESCRIPTION
Fix for missing clusters on printout when Print Task is used.
The _opacity property is added to give the user the opportunity to make the clusters transparent. Without setting the opacity on the Cluster layer itself, the clusters are not transparent. I personally, changed the cluster symbol colors and made them not transparent to have the same result on the printout. But this is a personal preference and I did not include it here. 
Also, if a ClassBreaksRenderer is set after the ClusterFeatureLayer is instantiated, the Print Task throws an error. So, in order for the Print Task to work, the provided ClassBreaksRenderer must be used.
